### PR TITLE
Make createGRPCError params optionals (JSDoc)

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = createGRPCError
 /**
  * Utility function that creates an Error suitable for gRPC responses.
  * See tests for all examples
- * @param  {String|Number|Error|Object} message If <code>String</code> the error message
+ * @param  {String|Number|Error|Object} [message] If <code>String</code> the error message
  *                                              If <code>Number</code> the error code
  *                                              If instanceof <code>Error</code>, the error to source data from. We still create a new
  *                                              <code>Error</code> instance, copy data from the passed error and assign / merge the rest
@@ -15,12 +15,12 @@ module.exports = createGRPCError
  *                                              or actual <code>grpc.Metadata</code> instance. We use
  *                                              <code>grpc-create-metadata</code> module to create metadata for the
  *                                              return value.
- * @param  {Number|Object} code If <code>Number</code> the error code
+ * @param  {Number|Object} [code] If <code>Number</code> the error code
  *                              If <code>Object</code>, assumed to be metadata, either plain object representation
  *                              or actual <code>grpc.Metadata</code> instance. We use
  *                              <code>grpc-create-metadata</code> module to create metadata for the
  *                              return value.
- * @param  {Object} metadata The error metadata. Either plain object representation or actual
+ * @param  {Object} [metadata] The error metadata. Either plain object representation or actual
  *                           <code>grpc.Metadata</code> instance. We use <code>grpc-create-metadata</code>
  *                           module to create metadata for the return value.
  * @return {Error} The new Error


### PR DESCRIPTION
Technically every param of the `createGRPCError` is optional because even though we call `createGRPCError` without any params, it will create an `Error` instance, so I'm pointing this in the of function's JSDoc.

I'm proposing this change because if you try to use this package in a Typescript it will complain because you're not passing an error code or metadata.   

*Without passing an error code*
![image](https://user-images.githubusercontent.com/5460365/87641183-bac5fe80-c715-11ea-9108-ae0d9223135b.png)

*Witout passing metadata*
![image](https://user-images.githubusercontent.com/5460365/87641287-dd581780-c715-11ea-961a-0fa39979561a.png)
<hr>

*With optional JSDoc*
![image](https://user-images.githubusercontent.com/5460365/87641742-8999fe00-c716-11ea-9caf-6e635975fa6e.png)

